### PR TITLE
Update BigInt dependency to allow versions from 5.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "TonSwift", targets: ["TonSwift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/attaswift/BigInt", .exact("5.3.0")),
+        .package(url: "https://github.com/attaswift/BigInt", from: "5.4.0"),
         .package(url: "https://github.com/bitmark-inc/tweetnacl-swiftwrap", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/jedisct1/swift-sodium", .exact("0.9.1"))
     ],


### PR DESCRIPTION
## Summary
- Replace exact pin on BigInt `5.3.0` with `from: "5.4.0"` in `Package.swift`, allowing newer compatible releases within the 5.x major.

## Motivation
The strict `.exact("5.3.0")` constraint forces every consumer of `TonSwift` to pin BigInt at 5.3.0, which causes resolution conflicts in projects that depend on newer BigInt releases. Loosening to `from: "5.4.0"` keeps SemVer guarantees while letting SwiftPM pick a compatible version.

## Test plan
- [x] `swift package resolve` succeeds
- [x] `swift build` succeeds
- [x] `swift test` passes